### PR TITLE
limit cloud run service name to 49 chars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "google_cloud_run_service" "probers" {
   for_each = toset(var.locations)
 
   project  = var.project_id
-  name     = "${var.name}-prb"
+  name     = "${format("%.45s", var.name)}-prb"
   location = each.key
 
   template {


### PR DESCRIPTION
- limit cloud run service name to 49 chars