### PR TITLE
shouldn't assume KO_DOCKER_REPO

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,14 @@ terraform {
   }
 }
 
+locals {
+  repo = var.repository != "" ? var.repository : "gcr.io/${var.project_id}"
+}
+
+provider "ko" {
+  repo = local.repo
+}
+
 // Create a service account for the prober to run as.
 resource "google_service_account" "prober" {
   project = var.project_id

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "google_service_account" "prober" {
 
 // Build the prober into an image we can run on Cloud Run.
 resource "ko_image" "image" {
-  base_image  = "cgr.dev/chainguard/static"
+  base_image  = var.base_image
   importpath  = var.importpath
   working_dir = var.working_dir
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,11 @@ variable "project_id" {
   description = "The project that will host the prober."
 }
 
+variable "base_image" {
+  type        = string
+  default     = "cgr.dev/chainguard/static"
+  description = "The base image that will be used to build the container image."
+}
 variable "importpath" {
   type        = string
   description = "The import path that contains the prober application."

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,13 @@ variable "base_image" {
   default     = "cgr.dev/chainguard/static"
   description = "The base image that will be used to build the container image."
 }
+
+variable "repository" {
+  type        = string
+  default     = ""
+  description = "Container repository to publish images to."
+}
+
 variable "importpath" {
   type        = string
   description = "The import path that contains the prober application."


### PR DESCRIPTION
- add option to define the base image
- shouldn't assume KO_DOCKER_REPO

tested that using the basic example


Fixes: #14 