### PR TITLE
Feature: Require specifying the Google Service Account to run as.

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -16,3 +16,7 @@ jobs:
           output-file: README.md
           output-method: inject
           fail-on-diff: "true"
+      - name: Dump README
+        if: failure()
+        run: |
+          cat README.md

--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ No modules.
 | [google_dns_record_set.prober_dns](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
 | [google_monitoring_uptime_check_config.global_uptime_check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_uptime_check_config) | resource |
 | [google_monitoring_uptime_check_config.regional_uptime_check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_uptime_check_config) | resource |
-| [google_service_account.prober](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [ko_image.image](https://registry.terraform.io/providers/ko-build/ko/latest/docs/resources/image) | resource |
 | [random_password.secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [google_iam_policy.noauth](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/iam_policy) | data source |
@@ -143,6 +142,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name to prefix to created resources. | `any` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project that will host the prober. | `string` | n/a | yes |
 | <a name="input_repository"></a> [repository](#input\_repository) | Container repository to publish images to. | `string` | `""` | no |
+| <a name="input_service-account"></a> [service-account](#input\_service-account) | The email address of the service account to run the service as. | `string` | n/a | yes |
 | <a name="input_working_dir"></a> [working\_dir](#input\_working\_dir) | The working directory that contains the importpath. | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/basic/example.tf
+++ b/examples/basic/example.tf
@@ -18,12 +18,18 @@ variable "project_id" {
   description = "The project that will host the prober."
 }
 
+resource "google_service_account" "prober" {
+  project = var.project_id
+  account_id = "basic-example-prober"
+}
+
 module "prober" {
   source  = "chainguard-dev/prober/google"
   version = "v0.1.2"
 
-  name       = "basic-example"
-  project_id = var.project_id
+  name            = "basic-example"
+  project_id      = var.project_id
+  service-account = google_service_account.prober.email
 
   importpath  = "github.com/chainguard-dev/terraform-google-prober/examples/basic"
   working_dir = path.module

--- a/examples/complex/example.tf
+++ b/examples/complex/example.tf
@@ -30,12 +30,18 @@ resource "google_dns_managed_zone" "prober-zone" {
   description = "This is the DNS zone for the complex example prober."
 }
 
+resource "google_service_account" "prober" {
+  project = var.project_id
+  account_id = "complex-example-prober"
+}
+
 module "prober" {
   source  = "chainguard-dev/prober/google"
   version = "v0.1.2"
 
-  name       = "complex-example"
-  project_id = var.project_id
+  name            = "complex-example"
+  project_id      = var.project_id
+  service-account = google_service_account.prober.email
 
   importpath  = "github.com/chainguard-dev/terraform-google-prober/examples/complex"
   working_dir = path.module

--- a/main.tf
+++ b/main.tf
@@ -15,22 +15,12 @@ terraform {
 }
 
 locals {
-  repo = var.repository != "" ? var.repository : "gcr.io/${var.project_id}"
-}
-
-provider "ko" {
-  repo = local.repo
-}
-
-// Create a service account for the prober to run as.
-resource "google_service_account" "prober" {
-  project = var.project_id
-  # Service accounts can be 30 characters long, so truncate var.name to 23 chars.
-  account_id = "${substr(var.name, 0, 23)}-prober"
+  repo = var.repository != "" ? var.repository : "gcr.io/${var.project_id}/${var.name}"
 }
 
 // Build the prober into an image we can run on Cloud Run.
 resource "ko_image" "image" {
+  repo        = local.repo
   base_image  = var.base_image
   importpath  = var.importpath
   working_dir = var.working_dir
@@ -57,7 +47,7 @@ resource "google_cloud_run_service" "probers" {
 
   template {
     spec {
-      service_account_name = google_service_account.prober.email
+      service_account_name = var.service-account
       containers {
         image = ko_image.image.image_ref
 

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,11 @@ variable "repository" {
   description = "Container repository to publish images to."
 }
 
+variable "service-account" {
+  type        = string
+  description = "The email address of the service account to run the service as."
+}
+
 variable "importpath" {
   type        = string
   description = "The import path that contains the prober application."


### PR DESCRIPTION
:gift: This changes the module to allow the caller to specify the google service account as which to run.

This allows the caller to have greater control over the service account name, and to authorize the service account to take actions prior to invoking the module to spin up the Cloud Run service.

/kind feature
