### PR TITLE
use ko_build TF resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ No modules.
 | [google_dns_record_set.prober_dns](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
 | [google_monitoring_uptime_check_config.global_uptime_check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_uptime_check_config) | resource |
 | [google_monitoring_uptime_check_config.regional_uptime_check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_uptime_check_config) | resource |
-| [ko_image.image](https://registry.terraform.io/providers/ko-build/ko/latest/docs/resources/image) | resource |
+| [ko_build.image](https://registry.terraform.io/providers/ko-build/ko/latest/docs/resources/image) | resource |
 | [random_password.secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [google_iam_policy.noauth](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/iam_policy) | data source |
 

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 // Build the prober into an image we can run on Cloud Run.
-resource "ko_image" "image" {
+resource "ko_build" "image" {
   repo        = local.repo
   base_image  = var.base_image
   importpath  = var.importpath
@@ -49,7 +49,7 @@ resource "google_cloud_run_service" "probers" {
     spec {
       service_account_name = var.service_account
       containers {
-        image = ko_image.image.image_ref
+        image = ko_build.image.image_ref
 
         // This is a shared secret with the uptime check, which must be
         // passed in an Authorization header for the probe to do work.


### PR DESCRIPTION
https://github.com/ko-build/terraform-provider-ko/pull/53 -- merged but not yet released -- changes the `ko_image` resource to be named `ko_build`. It keeps the `ko_image` resource defined, but a no-op, so that the resource can more easily be deleted.

Holding this PR until I cut a TF-ko release, which will break this config until this PR is merged.